### PR TITLE
C2: ConfigFile

### DIFF
--- a/cmake/SourceLists.official.cmake
+++ b/cmake/SourceLists.official.cmake
@@ -1,4 +1,6 @@
 set(SOURCES_LIST ${SOURCES_LIST}
     ${PROJECT_SOURCE_DIR}/src/lib.cpp
+${PROJECT_SOURCE_DIR}/src/dyn/config_map.hpp
+${PROJECT_SOURCE_DIR}/src/dyn/config_map.cpp
 ${PROJECT_SOURCE_DIR}/src/tasker/tasker.cpp
 )

--- a/include/circular/lib.hpp
+++ b/include/circular/lib.hpp
@@ -3,6 +3,7 @@
 #include <tuple>
 #include <vector>
 
+#include "../src/dyn/config_map.hpp"
 #include "tasker.hpp"
 
 /// \brief Accumulate a vector to produce the mean and the variance of the

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -5,4 +5,4 @@ set -x
 rm -f cmake/SourceLists.cmake
 cp cmake/SourceLists{.official,}.cmake
 
-mkdir -p build/ && cd build && cmake .. && cmake --build . && ./tests/tests
+mkdir -p build/ && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . && ./tests/tests --success

--- a/scripts/get_source_files.sh
+++ b/scripts/get_source_files.sh
@@ -8,7 +8,7 @@ set -x
 touch cmake/SourceLists.cmake
 touch cmake/SourceLists.txt
 
-find src/ -type f -name *.cpp -o -name *.h -o -name *.inl | 
+find src/ -type f -name *.cpp -o -name *.hpp -o -name *.inl |
     awk '{print "$${PROJECT_SOURCE_DIR}/"$1}' > cmake/SourceLists.txt
 
 rg --replace "$(cat cmake/SourceLists.txt)" --passthru --no-line-number \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Build libcircular #
 #####################
 
+# these are the PUBLIC headers only, not the ones in src/
 set(HEADER_LIST
   "${PROJECT_SOURCE_DIR}/include/circular/lib.hpp"
   "${PROJECT_SOURCE_DIR}/include/circular/tasker.hpp"

--- a/src/dyn/config_map.cpp
+++ b/src/dyn/config_map.cpp
@@ -93,3 +93,12 @@ void circular::ConfigMap::set_value(std::string section, std::string key,
     d.insert_or_assign(key, value);
   }
 }
+
+bool circular::ConfigMap::has_section(std::string section) const {
+  return _repr.contains(section);
+}
+
+bool circular::ConfigMap::has_section_key(std::string section,
+                                          std::string key) const {
+  return _repr.contains(section) && _repr.at(section).contains(key);
+}

--- a/src/dyn/config_map.cpp
+++ b/src/dyn/config_map.cpp
@@ -6,7 +6,7 @@ using namespace circular;
 
 void circular::ConfigMap::clear() { _repr.clear(); }
 
-void circular::ConfigMap::erase_section(std::string section) {
+void circular::ConfigMap::erase_section(const std::string &section) {
   auto f = _repr.find(section);
   if (f == _repr.end()) {
     throw std::out_of_range{
@@ -15,8 +15,8 @@ void circular::ConfigMap::erase_section(std::string section) {
   _repr.erase(f);
 }
 
-void circular::ConfigMap::erase_section_key(std::string section,
-                                            std::string key) {
+void circular::ConfigMap::erase_section_key(const std::string &section,
+                                            const std::string &key) {
   auto &d = _repr.at(section);
   auto k = d.find(key);
   if (k == d.end()) {
@@ -27,7 +27,7 @@ void circular::ConfigMap::erase_section_key(std::string section,
 }
 
 std::vector<std::string>
-circular::ConfigMap::get_section_keys(std::string section) const {
+circular::ConfigMap::get_section_keys(const std::string &section) const {
   auto d = _repr.at(section);
 
   std::vector<std::string> keys{};
@@ -49,8 +49,8 @@ std::vector<std::string> circular::ConfigMap::get_sections() const {
   return sections;
 }
 
-ConfigVariant circular::ConfigMap::get_value(std::string section,
-                                             std::string key,
+ConfigVariant circular::ConfigMap::get_value(const std::string &section,
+                                             const std::string &key,
                                              ConfigVariant default_value) {
   auto finds = _repr.find(section);
   if (finds == _repr.end()) {
@@ -74,7 +74,8 @@ ConfigVariant circular::ConfigMap::get_value(std::string section,
   return findk->second;
 }
 
-void circular::ConfigMap::set_value(std::string section, std::string key,
+void circular::ConfigMap::set_value(const std::string &section,
+                                    const std::string &key,
                                     ConfigVariant value) {
   auto finds = _repr.find(section);
   if (finds == _repr.end()) {
@@ -94,11 +95,11 @@ void circular::ConfigMap::set_value(std::string section, std::string key,
   }
 }
 
-bool circular::ConfigMap::has_section(std::string section) const {
+bool circular::ConfigMap::has_section(const std::string &section) const {
   return _repr.contains(section);
 }
 
-bool circular::ConfigMap::has_section_key(std::string section,
-                                          std::string key) const {
+bool circular::ConfigMap::has_section_key(const std::string &section,
+                                          const std::string &key) const {
   return _repr.contains(section) && _repr.at(section).contains(key);
 }

--- a/src/dyn/config_map.cpp
+++ b/src/dyn/config_map.cpp
@@ -1,0 +1,28 @@
+#include "config_map.hpp"
+
+using namespace circular;
+
+void circular::ConfigMap::clear() {}
+
+void circular::ConfigMap::erase_section(std::string section) {}
+
+void circular::ConfigMap::erase_section_key(std::string section,
+                                            std::string key) {}
+
+std::vector<std::string>
+circular::ConfigMap::get_section_keys(std::string section) const {
+  return std::vector<std::string>();
+}
+
+std::vector<std::string> circular::ConfigMap::get_sections() const {
+  return std::vector<std::string>();
+}
+
+ConfigVariant circular::ConfigMap::get_value(std::string section,
+                                             std::string key,
+                                             ConfigVariant default_value) {
+  return ConfigVariant();
+}
+
+void circular::ConfigMap::set_value(std::string section, std::string key,
+                                    ConfigVariant value) {}

--- a/src/dyn/config_map.cpp
+++ b/src/dyn/config_map.cpp
@@ -1,28 +1,95 @@
 #include "config_map.hpp"
 
+#include <stdexcept>
+
 using namespace circular;
 
-void circular::ConfigMap::clear() {}
+void circular::ConfigMap::clear() { _repr.clear(); }
 
-void circular::ConfigMap::erase_section(std::string section) {}
+void circular::ConfigMap::erase_section(std::string section) {
+  auto f = _repr.find(section);
+  if (f == _repr.end()) {
+    throw std::out_of_range{
+        "erase_section: trying to erase nonexistent section"};
+  }
+  _repr.erase(f);
+}
 
 void circular::ConfigMap::erase_section_key(std::string section,
-                                            std::string key) {}
+                                            std::string key) {
+  auto &d = _repr.at(section);
+  auto k = d.find(key);
+  if (k == d.end()) {
+    throw std::invalid_argument{
+        "erase_section_key: trying to erase nonexistent key"};
+  }
+  d.erase(k);
+}
 
 std::vector<std::string>
 circular::ConfigMap::get_section_keys(std::string section) const {
-  return std::vector<std::string>();
+  auto d = _repr.at(section);
+
+  std::vector<std::string> keys{};
+  keys.reserve(d.size());
+  for (const auto kv : d) {
+    keys.push_back(kv.first);
+  }
+
+  return keys;
 }
 
 std::vector<std::string> circular::ConfigMap::get_sections() const {
-  return std::vector<std::string>();
+  std::vector<std::string> sections{};
+  sections.reserve(_repr.size());
+  for (const auto kv : _repr) {
+    sections.push_back(kv.first);
+  }
+
+  return sections;
 }
 
 ConfigVariant circular::ConfigMap::get_value(std::string section,
                                              std::string key,
                                              ConfigVariant default_value) {
-  return ConfigVariant();
+  auto finds = _repr.find(section);
+  if (finds == _repr.end()) {
+    if (default_value == ConfigVariant{}) {
+      throw std::out_of_range{
+          "get_value: section not found, and default_value == std::monostate"};
+    }
+    return default_value;
+  }
+
+  auto &d = finds->second;
+  auto findk = d.find(key);
+  if (findk == d.end()) {
+    if (default_value == ConfigVariant{}) {
+      throw std::out_of_range{
+          "get_value: key not found, and default_value == std::monostate"};
+    }
+    return default_value;
+  }
+
+  return findk->second;
 }
 
 void circular::ConfigMap::set_value(std::string section, std::string key,
-                                    ConfigVariant value) {}
+                                    ConfigVariant value) {
+  auto finds = _repr.find(section);
+  if (finds == _repr.end()) {
+    _config_section_t new_section_repr{{key, value}};
+    _repr.emplace(std::make_pair(section, new_section_repr));
+    return;
+  }
+
+  auto &d = finds->second;
+  if (value == ConfigVariant{}) {
+    auto findk = d.find(key);
+    if (findk != d.end()) {
+      d.erase(findk);
+    }
+  } else {
+    d.insert_or_assign(key, value);
+  }
+}

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -34,7 +34,8 @@ using ConfigVariant =
  * std::string and values <-> ConfigVariant.
  */
 class ConfigMap {
-  using _config_map_repr_t = std::unordered_map<std::string, VariantDict>;
+  using _config_section_t = std::unordered_map<std::string, ConfigVariant>;
+  using _config_map_repr_t = std::unordered_map<std::string, _config_section_t>;
 
 public:
   ConfigMap() = default;
@@ -89,6 +90,6 @@ public:
   void set_value(std::string section, std::string key, ConfigVariant value);
 
 private:
-  _config_map_repr_t _repr;
+  _config_map_repr_t _repr{};
 };
 } // namespace circular

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -48,19 +48,19 @@ public:
   /// @param section The section to be erased.
   ///
   /// Throws if section does not exist.
-  void erase_section(std::string section);
+  void erase_section(const std::string &section);
 
   /// @brief erase a key-value pair.
   /// @param section The section of the key to be erased.
   /// @param key The key whose key-value pair is to be erased.
   ///
   /// Throws if either section or key do not exist.
-  void erase_section_key(std::string section, std::string key);
+  void erase_section_key(const std::string &section, const std::string &key);
 
   /// @brief list the keys present in a section.
   /// @param section The section for which a list of keys is desired.
   /// @return A vector of keys in that section (in no particular order).
-  std::vector<std::string> get_section_keys(std::string section) const;
+  std::vector<std::string> get_section_keys(const std::string &section) const;
 
   /// @brief List the sections present in the ConfigMap.
   /// @return A vector of sections in the ConfigMap (in no particular order).
@@ -77,7 +77,7 @@ public:
   /// failure (if default_value != std::monostate).
   ///
   /// Throws on lookup failure if default_value == std::monostate.
-  ConfigVariant get_value(std::string section, std::string key,
+  ConfigVariant get_value(const std::string &section, const std::string &key,
                           ConfigVariant default_value = ConfigVariant{});
 
   /// @brief Insert or assign a value in the ConfigMap.
@@ -87,19 +87,21 @@ public:
   /// (equivalently std::monostate) will delete the key (i.e., null it out).
   ///
   /// If either section or key do not exist, they will be created.
-  void set_value(std::string section, std::string key, ConfigVariant value);
+  void set_value(const std::string &section, const std::string &key,
+                 ConfigVariant value);
 
   /// @brief Test whether the ConfigMap contains a section with that name.
   /// @param section The section whose existence is in question.
   /// @return true if the ConfigMap contains a section with that name.
-  bool has_section(std::string section) const;
+  bool has_section(const std::string &section) const;
 
   /// @brief Test whether the ConfigMap contains a section and key with that
   /// name.
   /// @param section The section of the key whose existence is in question.
   /// @param key The key whose existence is in question.
   /// @return true if the ConfigMap contains a section/key with those names.
-  bool has_section_key(std::string section, std::string key) const;
+  bool has_section_key(const std::string &section,
+                       const std::string &key) const;
 
 private:
   _config_map_repr_t _repr{};

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -7,19 +7,24 @@
 
 namespace circular {
 
-class ConfigVariant;
-using VariantList = std::vector<ConfigVariant>;
-using VariantDict = std::unordered_map<std::string, ConfigVariant>;
-using ConfigVariant = std::variant<std::monostate, bool, int, double,
-                                   std::string, VariantList, VariantDict>;
+using PodVariant = std::variant<std::monostate, bool, int, double,
+                                std::string>; // no containers
+
+using VariantList = std::vector<PodVariant>;
+using VariantDict = std::unordered_map<std::string, PodVariant>;
+
+using ConfigVariant =
+    std::variant<std::monostate, bool, int, double, std::string, VariantList,
+                 VariantDict>; // has containers
 
 /**
  * @brief A two-level unordered_map from string sections/keys to variant values.
  *
- * ConfigMap is an STL-based analogue to godot::ConfigFile, with two
+ * ConfigMap is an STL-based analogue to godot::ConfigFile, with three
  * differences:
  * 1. no methods to read/write/parse/stringify; and
- * 2. values are restricted to {BOOL, INT, DOUBLE, STRING, ARRAY, DICT}.
+ * 2. values are restricted to {BOOL, INT, DOUBLE, STRING, ARRAY, DICT}, and
+ * 3. The ARRAY and DICT therein are limited to non-container types. Sorry.
  * It stores key-value pairs, with std::string keys and std::variant values.
  * These pairs are further collected into sections, identified by std::string
  * section keys.

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -47,7 +47,7 @@ public:
   /// @brief erase a single section and all its key-value pairs.
   /// @param section The section to be erased.
   ///
-  /// Throws if section does not exist.
+  /// Throws std::out_of_range if section does not exist.
   void erase_section(const std::string &section);
 
   /// @brief erase a key-value pair.
@@ -72,11 +72,12 @@ public:
   /// @param default_value The value to return if there is no value for
   /// section/key. If you don't want this to happen, passing ConfigVariant{}
   /// (equivalently std::monostate) will result in get_value throwing
-  /// std::[WHAT_EXCEPTION?] instead of returning anything on lookup failure.
+  /// std::out_of_range instead of returning anything on lookup failure.
   /// @return The value for the section/key, or the default value on lookup
   /// failure (if default_value != std::monostate).
   ///
-  /// Throws on lookup failure if default_value == std::monostate.
+  /// Throws std::out_of_range on lookup failure if default_value ==
+  /// std::monostate.
   ConfigVariant get_value(const std::string &section, const std::string &key,
                           ConfigVariant default_value = ConfigVariant{});
 

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -45,20 +45,20 @@ public:
   void clear();
 
   /// @brief erase a single section and all its key-value pairs.
-  /// @param section the section to be erased.
+  /// @param section The section to be erased.
   ///
   /// Throws if section does not exist.
   void erase_section(std::string section);
 
   /// @brief erase a key-value pair.
-  /// @param section the section of the key to be erased.
-  /// @param key the key whose key-value pair is to be erased.
+  /// @param section The section of the key to be erased.
+  /// @param key The key whose key-value pair is to be erased.
   ///
   /// Throws if either section or key do not exist.
   void erase_section_key(std::string section, std::string key);
 
   /// @brief list the keys present in a section.
-  /// @param section the section for which a list of keys is desired.
+  /// @param section The section for which a list of keys is desired.
   /// @return A vector of keys in that section (in no particular order).
   std::vector<std::string> get_section_keys(std::string section) const;
 
@@ -67,9 +67,9 @@ public:
   std::vector<std::string> get_sections() const;
 
   /// @brief Look up a value, and either return a default or throw if not found.
-  /// @param section the section of the key-value pair to be looked up.
-  /// @param key the key to look up.
-  /// @param default_value the value to return if there is no value for
+  /// @param section The section of the key-value pair to be looked up.
+  /// @param key The key to look up.
+  /// @param default_value The value to return if there is no value for
   /// section/key. If you don't want this to happen, passing ConfigVariant{}
   /// (equivalently std::monostate) will result in get_value throwing
   /// std::[WHAT_EXCEPTION?] instead of returning anything on lookup failure.
@@ -80,7 +80,7 @@ public:
   ConfigVariant get_value(std::string section, std::string key,
                           ConfigVariant default_value = ConfigVariant{});
 
-  /// @brief
+  /// @brief Insert or assign a value in the ConfigMap.
   /// @param section The section of the key-value pair to create.
   /// @param key The key whose value is to be set.
   /// @param value The value to be assigned. Passing ConfigVariant{}
@@ -88,6 +88,18 @@ public:
   ///
   /// If either section or key do not exist, they will be created.
   void set_value(std::string section, std::string key, ConfigVariant value);
+
+  /// @brief Test whether the ConfigMap contains a section with that name.
+  /// @param section The section whose existence is in question.
+  /// @return true if the ConfigMap contains a section with that name.
+  bool has_section(std::string section) const;
+
+  /// @brief Test whether the ConfigMap contains a section and key with that
+  /// name.
+  /// @param section The section of the key whose existence is in question.
+  /// @param key The key whose existence is in question.
+  /// @return true if the ConfigMap contains a section/key with those names.
+  bool has_section_key(std::string section, std::string key) const;
 
 private:
   _config_map_repr_t _repr{};

--- a/src/dyn/config_map.hpp
+++ b/src/dyn/config_map.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace circular {
+
+class ConfigVariant;
+using VariantList = std::vector<ConfigVariant>;
+using VariantDict = std::unordered_map<std::string, ConfigVariant>;
+using ConfigVariant = std::variant<std::monostate, bool, int, double,
+                                   std::string, VariantList, VariantDict>;
+
+/**
+ * @brief A two-level unordered_map from string sections/keys to variant values.
+ *
+ * ConfigMap is an STL-based analogue to godot::ConfigFile, with two
+ * differences:
+ * 1. no methods to read/write/parse/stringify; and
+ * 2. values are restricted to {BOOL, INT, DOUBLE, STRING, ARRAY, DICT}.
+ * It stores key-value pairs, with std::string keys and std::variant values.
+ * These pairs are further collected into sections, identified by std::string
+ * section keys.
+ *
+ * The consumer should handle conversion to and from godot::ConfigFile,
+ * including the rules for transforming keys/sections <->
+ * std::string and values <-> ConfigVariant.
+ */
+class ConfigMap {
+  using _config_map_repr_t = std::unordered_map<std::string, VariantDict>;
+
+public:
+  ConfigMap() = default;
+  ~ConfigMap() = default;
+
+  /// @brief erase all sections and keys, making the ConfigMap empty.
+  void clear();
+
+  /// @brief erase a single section and all its key-value pairs.
+  /// @param section the section to be erased.
+  ///
+  /// Throws if section does not exist.
+  void erase_section(std::string section);
+
+  /// @brief erase a key-value pair.
+  /// @param section the section of the key to be erased.
+  /// @param key the key whose key-value pair is to be erased.
+  ///
+  /// Throws if either section or key do not exist.
+  void erase_section_key(std::string section, std::string key);
+
+  /// @brief list the keys present in a section.
+  /// @param section the section for which a list of keys is desired.
+  /// @return A vector of keys in that section (in no particular order).
+  std::vector<std::string> get_section_keys(std::string section) const;
+
+  /// @brief List the sections present in the ConfigMap.
+  /// @return A vector of sections in the ConfigMap (in no particular order).
+  std::vector<std::string> get_sections() const;
+
+  /// @brief Look up a value, and either return a default or throw if not found.
+  /// @param section the section of the key-value pair to be looked up.
+  /// @param key the key to look up.
+  /// @param default_value the value to return if there is no value for
+  /// section/key. If you don't want this to happen, passing ConfigVariant{}
+  /// (equivalently std::monostate) will result in get_value throwing
+  /// std::[WHAT_EXCEPTION?] instead of returning anything on lookup failure.
+  /// @return The value for the section/key, or the default value on lookup
+  /// failure (if default_value != std::monostate).
+  ///
+  /// Throws on lookup failure if default_value == std::monostate.
+  ConfigVariant get_value(std::string section, std::string key,
+                          ConfigVariant default_value = ConfigVariant{});
+
+  /// @brief
+  /// @param section The section of the key-value pair to create.
+  /// @param key The key whose value is to be set.
+  /// @param value The value to be assigned. Passing ConfigVariant{}
+  /// (equivalently std::monostate) will delete the key (i.e., null it out).
+  ///
+  /// If either section or key do not exist, they will be created.
+  void set_value(std::string section, std::string key, ConfigVariant value);
+
+private:
+  _config_map_repr_t _repr;
+};
+} // namespace circular

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ FetchContent_Declare(
   GIT_TAG v3.3.2)
 FetchContent_MakeAvailable(catch)
 
-add_executable(tests test.cpp tasker.cpp)
+add_executable(tests test.cpp tasker.cpp config_map.cpp)
 
 set_target_properties(tests
   PROPERTIES

--- a/tests/config_map.cpp
+++ b/tests/config_map.cpp
@@ -69,3 +69,17 @@ TEST_CASE("ConfigMap deletes keys", "[config_map]") {
   REQUIRE(m.get_section_keys("").size() == 1);
   REQUIRE(m.get_section_keys("sec").size() == 0);
 }
+
+TEST_CASE("ConfigMap can test for section and key existence", "[config_map]") {
+  circular::ConfigMap m{};
+
+  m.set_value("", "foo", 19);
+  m.set_value("sec", "bar", 7);
+
+  REQUIRE(m.has_section("sec") == true);
+  REQUIRE(m.has_section("baz") == false);
+
+  REQUIRE(m.has_section_key("sec", "bar") == true);
+  REQUIRE(m.has_section_key("sec", "qux") == false);
+  REQUIRE(m.has_section_key("ick", "foo") == false);
+}

--- a/tests/config_map.cpp
+++ b/tests/config_map.cpp
@@ -1,0 +1,16 @@
+#include <catch2/catch_all.hpp>
+#include <circular/lib.hpp>
+
+#include <vector>
+
+TEST_CASE("ConfigMap stores and gets ConfigVariants of various types",
+          "[config_map]") {
+  circular::VariantList l{1.0, 1};
+
+  circular::ConfigMap m{};
+  m.set_value("", "a_bool", true);
+  m.set_value("", "an_int", 1);
+  m.set_value("", "a_float", 1.0);
+  m.set_value("", "a_string", "foo");
+  m.set_value("", "a_list", l);
+}

--- a/tests/config_map.cpp
+++ b/tests/config_map.cpp
@@ -58,3 +58,14 @@ TEST_CASE("ConfigMap throws on lookup failure if defaulted to std::monostate",
   REQUIRE_THROWS(m.get_value("foo", "bar"));
   REQUIRE_THROWS(m.get_value("foo", "bar", std::monostate{}));
 }
+
+TEST_CASE("ConfigMap deletes keys", "[config_map]") {
+  circular::ConfigMap m{};
+
+  m.set_value("", "foo", 19);
+  m.set_value("sec", "bar", 7);
+  m.erase_section_key("sec", "bar");
+
+  REQUIRE(m.get_section_keys("").size() == 1);
+  REQUIRE(m.get_section_keys("sec").size() == 0);
+}

--- a/tests/config_map.cpp
+++ b/tests/config_map.cpp
@@ -5,12 +5,49 @@
 
 TEST_CASE("ConfigMap stores and gets ConfigVariants of various types",
           "[config_map]") {
-  circular::VariantList l{1.0, 1};
+  circular::VariantList l{true, 2.0, 42, "bar"};
+  circular::VariantDict d{{"baz", true}, {"qux", 24601}};
 
   circular::ConfigMap m{};
+
+  // set the values
   m.set_value("", "a_bool", true);
   m.set_value("", "an_int", 1);
-  m.set_value("", "a_float", 1.0);
+  m.set_value("", "a_double", 1.0);
   m.set_value("", "a_string", "foo");
-  m.set_value("", "a_list", l);
+  m.set_value("sec", "a_list", l);
+  m.set_value("sec", "a_dict", d);
+
+  auto bool_as_variant = m.get_value("", "a_bool", false);
+  REQUIRE(std::get<bool>(bool_as_variant) == true);
+
+  auto int_as_variant = m.get_value("", "an_int", 0);
+  REQUIRE(std::get<int>(int_as_variant) == 1);
+
+  auto double_as_variant = m.get_value("", "a_float", 0);
+  REQUIRE(std::get<double>(double_as_variant) == 1.0);
+
+  auto string_as_variant = m.get_value("", "a_string", "");
+  REQUIRE(std::get<std::string>(string_as_variant) == "foo");
+
+  auto list_as_variant = m.get_value("sec", "a_list", "");
+  REQUIRE(std::get<circular::VariantList>(string_as_variant) == l);
+}
+
+TEST_CASE("ConfigMap returns a default on lookup failure", "[config_map]") {
+  circular::ConfigMap m{};
+
+  m.set_value("", "foo", 19);
+  m.set_value("sec", "bar", 7);
+
+  REQUIRE(std::get<int>(m.get_value("", "baz", 3)) == 3);
+  REQUIRE(std::get<int>(m.get_value("qux", "foo", 5)) == 5);
+}
+
+TEST_CASE("ConfigMap throws on lookup failure if defaulted to std::monostate",
+          "") {
+  circular::ConfigMap m{};
+
+  REQUIRE_THROWS(m.get_value("foo", "bar"));
+  REQUIRE_THROWS(m.get_value("foo", "bar", std::monostate{}));
 }

--- a/tests/config_map.cpp
+++ b/tests/config_map.cpp
@@ -18,20 +18,27 @@ TEST_CASE("ConfigMap stores and gets ConfigVariants of various types",
   m.set_value("sec", "a_list", l);
   m.set_value("sec", "a_dict", d);
 
-  auto bool_as_variant = m.get_value("", "a_bool", false);
+  auto bool_as_variant = m.get_value("", "a_bool", circular::ConfigVariant{});
   REQUIRE(std::get<bool>(bool_as_variant) == true);
 
-  auto int_as_variant = m.get_value("", "an_int", 0);
+  auto int_as_variant = m.get_value("", "an_int", circular::ConfigVariant{});
   REQUIRE(std::get<int>(int_as_variant) == 1);
 
-  auto double_as_variant = m.get_value("", "a_float", 0);
+  auto double_as_variant =
+      m.get_value("", "a_double", circular::ConfigVariant{});
   REQUIRE(std::get<double>(double_as_variant) == 1.0);
 
-  auto string_as_variant = m.get_value("", "a_string", "");
+  auto string_as_variant =
+      m.get_value("", "a_string", circular::ConfigVariant{});
   REQUIRE(std::get<std::string>(string_as_variant) == "foo");
 
-  auto list_as_variant = m.get_value("sec", "a_list", "");
-  REQUIRE(std::get<circular::VariantList>(string_as_variant) == l);
+  auto list_as_variant =
+      m.get_value("sec", "a_list", circular::ConfigVariant{});
+  REQUIRE(std::get<circular::VariantList>(list_as_variant) == l);
+
+  auto dict_as_variant =
+      m.get_value("sec", "a_dict", circular::ConfigVariant{});
+  REQUIRE(std::get<circular::VariantDict>(dict_as_variant) == d);
 }
 
 TEST_CASE("ConfigMap returns a default on lookup failure", "[config_map]") {


### PR DESCRIPTION
closes #3.

I restricted `VariantList` and `VariantDict` to not having nested containers of their own (but only POD types) so that they could all be declared with using-directives.  On one hand, I don't like this, but OTOH I know that the needs of `World`'s ICs (i.e. those of `pan-gaia`) and those include exactly one `godot::Dictionary` for gas species. 2D data can be done with indexing 1D arrays (or just point to a filename...).